### PR TITLE
Update to beta 7 and cleanup Simulation example

### DIFF
--- a/cpp/CANcoder/build.gradle
+++ b/cpp/CANcoder/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "cpp"
     id "google-test-test-suite"
-    id "edu.wpi.first.GradleRIO" version "2023.1.1-beta-6"
+    id "edu.wpi.first.GradleRIO" version "2023.1.1-beta-7"
 }
 
 // Define my targets (RoboRIO) and artifacts (deployable files)

--- a/cpp/CANcoder/vendordeps/PhoenixPro.json
+++ b/cpp/CANcoder/vendordeps/PhoenixPro.json
@@ -1,7 +1,7 @@
 {
     "fileName": "PhoenixPro.json",
     "name": "CTRE-PhoenixPro",
-    "version": "23.0.0-beta-6",
+    "version": "23.0.0-beta-7",
     "frcYear": 2023,
     "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
     "mavenUrls": [
@@ -12,14 +12,14 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "wpiapi-java",
-            "version": "23.0.0-beta-6"
+            "version": "23.0.0-beta-7"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "tools",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -32,7 +32,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -45,7 +45,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -58,7 +58,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -71,7 +71,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -84,7 +84,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -97,7 +97,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -110,7 +110,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -123,7 +123,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -136,7 +136,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -151,7 +151,7 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "wpiapi-cpp",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixPro_WPI",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -166,7 +166,7 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "tools",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixTools",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -181,7 +181,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "wpiapi-cpp-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixPro_WPISim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -196,7 +196,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixTools_Sim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -211,7 +211,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimTalonSRX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -226,7 +226,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -241,7 +241,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimVictorSPX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -256,7 +256,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimPigeonIMU",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -271,7 +271,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimCANCoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -286,7 +286,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -301,7 +301,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProCANcoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -316,7 +316,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProPigeon2",
             "headerClassifier": "headers",
             "sharedLibrary": true,

--- a/cpp/CommandBasedDrive/build.gradle
+++ b/cpp/CommandBasedDrive/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "cpp"
     id "google-test-test-suite"
-    id "edu.wpi.first.GradleRIO" version "2023.1.1-beta-6"
+    id "edu.wpi.first.GradleRIO" version "2023.1.1-beta-7"
 }
 
 // Define my targets (RoboRIO) and artifacts (deployable files)

--- a/cpp/CommandBasedDrive/src/main/cpp/subsystems/DriveSubsystem.cpp
+++ b/cpp/CommandBasedDrive/src/main/cpp/subsystems/DriveSubsystem.cpp
@@ -44,11 +44,11 @@ DriveSubsystem::DriveSubsystem()
      * WPILib expects +V to be forward. Specify orientations to match that behavior.
      */
     /* left TalonFXs are CCW+ */
-    m_leftSimState.orientation = sim::ChassisReference::CounterClockwise_Positive;
-    m_leftFollowerSimState.orientation = sim::ChassisReference::CounterClockwise_Positive;
+    m_leftSimState.Orientation = sim::ChassisReference::CounterClockwise_Positive;
+    m_leftFollowerSimState.Orientation = sim::ChassisReference::CounterClockwise_Positive;
     /* right TalonFXs are CW+ */
-    m_rightSimState.orientation = sim::ChassisReference::Clockwise_Positive;
-    m_rightFollowerSimState.orientation = sim::ChassisReference::Clockwise_Positive;
+    m_rightSimState.Orientation = sim::ChassisReference::Clockwise_Positive;
+    m_rightFollowerSimState.Orientation = sim::ChassisReference::Clockwise_Positive;
 
     /* Publish field pose data to read back from */
     frc::SmartDashboard::PutData("Field", &m_field);

--- a/cpp/CommandBasedDrive/vendordeps/PhoenixPro.json
+++ b/cpp/CommandBasedDrive/vendordeps/PhoenixPro.json
@@ -1,7 +1,7 @@
 {
     "fileName": "PhoenixPro.json",
     "name": "CTRE-PhoenixPro",
-    "version": "23.0.0-beta-6",
+    "version": "23.0.0-beta-7",
     "frcYear": 2023,
     "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
     "mavenUrls": [
@@ -12,14 +12,14 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "wpiapi-java",
-            "version": "23.0.0-beta-6"
+            "version": "23.0.0-beta-7"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "tools",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -32,7 +32,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -45,7 +45,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -58,7 +58,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -71,7 +71,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -84,7 +84,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -97,7 +97,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -110,7 +110,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -123,7 +123,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -136,7 +136,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -151,7 +151,7 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "wpiapi-cpp",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixPro_WPI",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -166,7 +166,7 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "tools",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixTools",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -181,7 +181,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "wpiapi-cpp-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixPro_WPISim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -196,7 +196,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixTools_Sim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -211,7 +211,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimTalonSRX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -226,7 +226,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -241,7 +241,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimVictorSPX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -256,7 +256,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimPigeonIMU",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -271,7 +271,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimCANCoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -286,7 +286,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -301,7 +301,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProCANcoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -316,7 +316,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProPigeon2",
             "headerClassifier": "headers",
             "sharedLibrary": true,

--- a/cpp/Falcon500ArcadeDrive/build.gradle
+++ b/cpp/Falcon500ArcadeDrive/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "cpp"
     id "google-test-test-suite"
-    id "edu.wpi.first.GradleRIO" version "2023.1.1-beta-6"
+    id "edu.wpi.first.GradleRIO" version "2023.1.1-beta-7"
 }
 
 // Define my targets (RoboRIO) and artifacts (deployable files)

--- a/cpp/Falcon500ArcadeDrive/src/main/cpp/Robot.cpp
+++ b/cpp/Falcon500ArcadeDrive/src/main/cpp/Robot.cpp
@@ -13,8 +13,8 @@ void Robot::RobotInit() {
   configs::TalonFXConfiguration rightConfiguration{};
 
   /* User can optionally change the configs, or leave it alone to perform a factory default */
-  leftConfiguration.MotorOutput.Inverted = false;
-  rightConfiguration.MotorOutput.Inverted = true;
+  leftConfiguration.MotorOutput.Inverted = signals::InvertedValue::CounterClockwise_Positive;
+  rightConfiguration.MotorOutput.Inverted = signals::InvertedValue::Clockwise_Positive;
 
   leftLeader.GetConfigurator().Apply(leftConfiguration);
   leftFollower.GetConfigurator().Apply(leftConfiguration);

--- a/cpp/Falcon500ArcadeDrive/vendordeps/PhoenixPro.json
+++ b/cpp/Falcon500ArcadeDrive/vendordeps/PhoenixPro.json
@@ -1,7 +1,7 @@
 {
     "fileName": "PhoenixPro.json",
     "name": "CTRE-PhoenixPro",
-    "version": "23.0.0-beta-6",
+    "version": "23.0.0-beta-7",
     "frcYear": 2023,
     "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
     "mavenUrls": [
@@ -12,14 +12,14 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "wpiapi-java",
-            "version": "23.0.0-beta-6"
+            "version": "23.0.0-beta-7"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "tools",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -32,7 +32,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -45,7 +45,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -58,7 +58,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -71,7 +71,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -84,7 +84,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -97,7 +97,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -110,7 +110,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -123,7 +123,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -136,7 +136,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -151,7 +151,7 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "wpiapi-cpp",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixPro_WPI",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -166,7 +166,7 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "tools",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixTools",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -181,7 +181,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "wpiapi-cpp-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixPro_WPISim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -196,7 +196,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixTools_Sim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -211,7 +211,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimTalonSRX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -226,7 +226,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -241,7 +241,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimVictorSPX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -256,7 +256,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimPigeonIMU",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -271,7 +271,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimCANCoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -286,7 +286,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -301,7 +301,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProCANcoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -316,7 +316,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProPigeon2",
             "headerClassifier": "headers",
             "sharedLibrary": true,

--- a/cpp/Pigeon2/build.gradle
+++ b/cpp/Pigeon2/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "cpp"
     id "google-test-test-suite"
-    id "edu.wpi.first.GradleRIO" version "2023.1.1-beta-6"
+    id "edu.wpi.first.GradleRIO" version "2023.1.1-beta-7"
 }
 
 // Define my targets (RoboRIO) and artifacts (deployable files)

--- a/cpp/Pigeon2/vendordeps/PhoenixPro.json
+++ b/cpp/Pigeon2/vendordeps/PhoenixPro.json
@@ -1,7 +1,7 @@
 {
     "fileName": "PhoenixPro.json",
     "name": "CTRE-PhoenixPro",
-    "version": "23.0.0-beta-6",
+    "version": "23.0.0-beta-7",
     "frcYear": 2023,
     "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
     "mavenUrls": [
@@ -12,14 +12,14 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "wpiapi-java",
-            "version": "23.0.0-beta-6"
+            "version": "23.0.0-beta-7"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "tools",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -32,7 +32,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -45,7 +45,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -58,7 +58,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -71,7 +71,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -84,7 +84,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -97,7 +97,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -110,7 +110,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -123,7 +123,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -136,7 +136,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -151,7 +151,7 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "wpiapi-cpp",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixPro_WPI",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -166,7 +166,7 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "tools",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixTools",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -181,7 +181,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "wpiapi-cpp-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixPro_WPISim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -196,7 +196,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixTools_Sim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -211,7 +211,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimTalonSRX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -226,7 +226,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -241,7 +241,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimVictorSPX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -256,7 +256,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimPigeonIMU",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -271,7 +271,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimCANCoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -286,7 +286,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -301,7 +301,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProCANcoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -316,7 +316,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProPigeon2",
             "headerClassifier": "headers",
             "sharedLibrary": true,

--- a/cpp/PositionClosedLoop/build.gradle
+++ b/cpp/PositionClosedLoop/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "cpp"
     id "google-test-test-suite"
-    id "edu.wpi.first.GradleRIO" version "2023.1.1-beta-6"
+    id "edu.wpi.first.GradleRIO" version "2023.1.1-beta-7"
 }
 
 // Define my targets (RoboRIO) and artifacts (deployable files)

--- a/cpp/PositionClosedLoop/vendordeps/PhoenixPro.json
+++ b/cpp/PositionClosedLoop/vendordeps/PhoenixPro.json
@@ -1,7 +1,7 @@
 {
     "fileName": "PhoenixPro.json",
     "name": "CTRE-PhoenixPro",
-    "version": "23.0.0-beta-6",
+    "version": "23.0.0-beta-7",
     "frcYear": 2023,
     "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
     "mavenUrls": [
@@ -12,14 +12,14 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "wpiapi-java",
-            "version": "23.0.0-beta-6"
+            "version": "23.0.0-beta-7"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "tools",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -32,7 +32,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -45,7 +45,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -58,7 +58,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -71,7 +71,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -84,7 +84,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -97,7 +97,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -110,39 +110,39 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
                 "windowsx86-64",
                 "linuxx86-64",
-                "osxx86-64"
+                "osxuniversal"
             ],
             "simMode": "swsim"
         },
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
                 "windowsx86-64",
                 "linuxx86-64",
-                "osxx86-64"
+                "osxuniversal"
             ],
             "simMode": "swsim"
         },
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
                 "windowsx86-64",
                 "linuxx86-64",
-                "osxx86-64"
+                "osxuniversal"
             ],
             "simMode": "swsim"
         }
@@ -151,7 +151,7 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "wpiapi-cpp",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixPro_WPI",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -166,7 +166,7 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "tools",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixTools",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -181,7 +181,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "wpiapi-cpp-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixPro_WPISim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -196,7 +196,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixTools_Sim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -211,7 +211,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimTalonSRX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -226,7 +226,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -241,7 +241,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimVictorSPX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -256,7 +256,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimPigeonIMU",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -271,7 +271,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimCANCoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -286,7 +286,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -294,14 +294,14 @@
             "binaryPlatforms": [
                 "windowsx86-64",
                 "linuxx86-64",
-                "osxx86-64"
+                "osxuniversal"
             ],
             "simMode": "swsim"
         },
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProCANcoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -309,14 +309,14 @@
             "binaryPlatforms": [
                 "windowsx86-64",
                 "linuxx86-64",
-                "osxx86-64"
+                "osxuniversal"
             ],
             "simMode": "swsim"
         },
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProPigeon2",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -324,7 +324,7 @@
             "binaryPlatforms": [
                 "windowsx86-64",
                 "linuxx86-64",
-                "osxx86-64"
+                "osxuniversal"
             ],
             "simMode": "swsim"
         }

--- a/cpp/Simulation/build.gradle
+++ b/cpp/Simulation/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "cpp"
     id "google-test-test-suite"
-    id "edu.wpi.first.GradleRIO" version "2023.1.1-beta-6"
+    id "edu.wpi.first.GradleRIO" version "2023.1.1-beta-7"
 }
 
 // Define my targets (RoboRIO) and artifacts (deployable files)

--- a/cpp/Simulation/src/main/cpp/Robot.cpp
+++ b/cpp/Simulation/src/main/cpp/Robot.cpp
@@ -14,14 +14,14 @@ void Robot::RobotInit()
   ctre::phoenix::StatusCode returnCode;
 
   configs::TalonFXConfiguration fxCfg{};
-  fxCfg.MotorOutput.Inverted = spns::InvertedValue::CounterClockwise_Positive;
+  fxCfg.MotorOutput.Inverted = signals::InvertedValue::CounterClockwise_Positive;
   do
   {
     returnCode = leftFX.GetConfigurator().Apply(fxCfg);
   }
   while (!returnCode.IsOK());
 
-  fxCfg.MotorOutput.Inverted = spns::InvertedValue::Clockwise_Positive;
+  fxCfg.MotorOutput.Inverted = signals::InvertedValue::Clockwise_Positive;
   do
   {
     returnCode = rightFX.GetConfigurator().Apply(fxCfg);
@@ -29,9 +29,9 @@ void Robot::RobotInit()
   while (!returnCode.IsOK());
 
   configs::CANcoderConfiguration ccCfg{};
-  ccCfg.MagnetSensor.SensorDirection = spns::CANcoder_SensorDirectionValue::CounterClockwise_Positive;
+  ccCfg.MagnetSensor.SensorDirection = signals::CANcoder_SensorDirectionValue::CounterClockwise_Positive;
   leftSensor.GetConfigurator().Apply(ccCfg);
-  ccCfg.MagnetSensor.SensorDirection = spns::CANcoder_SensorDirectionValue::Clockwise_Positive;
+  ccCfg.MagnetSensor.SensorDirection = signals::CANcoder_SensorDirectionValue::Clockwise_Positive;
   rightSensor.GetConfigurator().Apply(ccCfg);
 
   configs::Pigeon2Configuration imuCfg{};
@@ -100,11 +100,11 @@ void Robot::SimulationInit()
    * WPILib expects +V to be forward. Specify orientations to match that behavior.
    */
   /* left devices are CCW+ */
-  leftSim.orientation = sim::ChassisReference::CounterClockwise_Positive;
-  leftSensSim.orientation = sim::ChassisReference::CounterClockwise_Positive;
+  leftSim.Orientation = sim::ChassisReference::CounterClockwise_Positive;
+  leftSensSim.Orientation = sim::ChassisReference::CounterClockwise_Positive;
   /* right devices are CW+ */
-  rightSim.orientation = sim::ChassisReference::Clockwise_Positive;
-  rightSensSim.orientation = sim::ChassisReference::Clockwise_Positive;
+  rightSim.Orientation = sim::ChassisReference::Clockwise_Positive;
+  rightSensSim.Orientation = sim::ChassisReference::Clockwise_Positive;
 }
 void Robot::SimulationPeriodic()
 {

--- a/cpp/Simulation/src/main/include/Robot.h
+++ b/cpp/Simulation/src/main/include/Robot.h
@@ -16,26 +16,32 @@
 #include <units/velocity.h>
 
 class Robot : public frc::TimedRobot {
-  ctre::phoenixpro::hardware::TalonFX leftFX{0};
-  ctre::phoenixpro::hardware::TalonFX rightFX{1};
-  ctre::phoenixpro::hardware::CANcoder leftSensor{0};
-  ctre::phoenixpro::hardware::CANcoder rightSensor{1};
-  ctre::phoenixpro::hardware::Pigeon2 imu{0};
+  // all CTRE devices are assumed to be on a canivore bus named "mycanivore"
+  ctre::phoenixpro::hardware::TalonFX leftLeader{1, kCanivoreName};
+  ctre::phoenixpro::hardware::TalonFX rightLeader{2, kCanivoreName};
+  ctre::phoenixpro::hardware::TalonFX leftFollower{3, kCanivoreName};
+  ctre::phoenixpro::hardware::TalonFX rightFollower{4, kCanivoreName};
 
-  ctre::phoenixpro::sim::TalonFXSimState &leftSim = leftFX.GetSimState();
-  ctre::phoenixpro::sim::TalonFXSimState &rightSim = rightFX.GetSimState();
+  ctre::phoenixpro::hardware::CANcoder leftSensor{0, kCanivoreName};
+  ctre::phoenixpro::hardware::CANcoder rightSensor{1, kCanivoreName};
+
+  ctre::phoenixpro::hardware::Pigeon2 imu{0, kCanivoreName};
+
+  // create sim state objects for handling simulation IO
+  ctre::phoenixpro::sim::TalonFXSimState &leftSim = leftLeader.GetSimState();
+  ctre::phoenixpro::sim::TalonFXSimState &rightSim = rightLeader.GetSimState();
   ctre::phoenixpro::sim::CANcoderSimState &leftSensSim = leftSensor.GetSimState();
   ctre::phoenixpro::sim::CANcoderSimState &rightSensSim = rightSensor.GetSimState();
   ctre::phoenixpro::sim::Pigeon2SimState &imuSim = imu.GetSimState();
 
-  frc::DifferentialDrive drivetrain{leftFX, rightFX};
+  frc::DifferentialDrive drivetrain{leftLeader, rightLeader};
 
   frc::XboxController joystick{0};
 
   /*
     * These numbers are an example AndyMark Drivetrain with some additional weight.
     * This is a fairly light robot.
-    * Note you can utilize results from robot characterization instead of
+    * Note: you can utilize results from robot characterization instead of
     * theoretical numbers.
     * https://docs.wpilib.org/en/stable/docs/software/wpilib-tools/robot-
     * characterization/introduction.html#introduction-to-robot-characterization
@@ -43,7 +49,7 @@ class Robot : public frc::TimedRobot {
   static constexpr units::dimensionless::scalar_t kGearRatio = 10.71; // Standard AndyMark Gearing reduction.
   static constexpr units::inch_t kWheelRadiusInches = 3_in;
 
-  frc::sim::DifferentialDrivetrainSim m_driveSim{
+  frc::sim::DifferentialDrivetrainSim m_driveSim {
     frc::DCMotor::Falcon500(2),
     kGearRatio,
     2.1_kg_sq_m, // MOI of 2.1 kg m^2 (from CAD model)
@@ -52,9 +58,11 @@ class Robot : public frc::TimedRobot {
     0.546_m,     // Distance between wheels is _ meters.
   };
 
+  std::string kCanivoreName = "mcanivore";
+
   frc::Field2d m_field{};
 
-  frc::DifferentialDriveOdometry m_odometry{
+  frc::DifferentialDriveOdometry m_odometry {
     imu.GetRotation2d(),
     0_m, 0_m
   };

--- a/cpp/Simulation/vendordeps/PhoenixPro.json
+++ b/cpp/Simulation/vendordeps/PhoenixPro.json
@@ -1,7 +1,7 @@
 {
     "fileName": "PhoenixPro.json",
     "name": "CTRE-PhoenixPro",
-    "version": "23.0.0-beta-6",
+    "version": "23.0.0-beta-7",
     "frcYear": 2023,
     "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
     "mavenUrls": [
@@ -12,14 +12,14 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "wpiapi-java",
-            "version": "23.0.0-beta-6"
+            "version": "23.0.0-beta-7"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "tools",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -32,7 +32,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -45,7 +45,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -58,7 +58,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -71,7 +71,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -84,7 +84,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -97,7 +97,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -110,7 +110,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -123,7 +123,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -136,7 +136,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -151,7 +151,7 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "wpiapi-cpp",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixPro_WPI",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -166,7 +166,7 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "tools",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixTools",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -181,7 +181,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "wpiapi-cpp-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixPro_WPISim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -196,7 +196,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixTools_Sim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -211,7 +211,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimTalonSRX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -226,7 +226,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -241,7 +241,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimVictorSPX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -256,7 +256,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimPigeonIMU",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -271,7 +271,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimCANCoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -286,7 +286,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -301,7 +301,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProCANcoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -316,7 +316,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProPigeon2",
             "headerClassifier": "headers",
             "sharedLibrary": true,

--- a/cpp/VelocityClosedLoop/build.gradle
+++ b/cpp/VelocityClosedLoop/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "cpp"
     id "google-test-test-suite"
-    id "edu.wpi.first.GradleRIO" version "2023.1.1-beta-6"
+    id "edu.wpi.first.GradleRIO" version "2023.1.1-beta-7"
 }
 
 // Define my targets (RoboRIO) and artifacts (deployable files)

--- a/cpp/VelocityClosedLoop/vendordeps/PhoenixPro.json
+++ b/cpp/VelocityClosedLoop/vendordeps/PhoenixPro.json
@@ -1,7 +1,7 @@
 {
     "fileName": "PhoenixPro.json",
     "name": "CTRE-PhoenixPro",
-    "version": "23.0.0-beta-6",
+    "version": "23.0.0-beta-7",
     "frcYear": 2023,
     "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
     "mavenUrls": [
@@ -12,14 +12,14 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "wpiapi-java",
-            "version": "23.0.0-beta-6"
+            "version": "23.0.0-beta-7"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "tools",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -32,7 +32,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -45,7 +45,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -58,7 +58,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -71,7 +71,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -84,7 +84,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -97,7 +97,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -110,39 +110,39 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
                 "windowsx86-64",
                 "linuxx86-64",
-                "osxx86-64"
+                "osxuniversal"
             ],
             "simMode": "swsim"
         },
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
                 "windowsx86-64",
                 "linuxx86-64",
-                "osxx86-64"
+                "osxuniversal"
             ],
             "simMode": "swsim"
         },
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
                 "windowsx86-64",
                 "linuxx86-64",
-                "osxx86-64"
+                "osxuniversal"
             ],
             "simMode": "swsim"
         }
@@ -151,7 +151,7 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "wpiapi-cpp",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixPro_WPI",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -166,7 +166,7 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "tools",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixTools",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -181,7 +181,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "wpiapi-cpp-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixPro_WPISim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -196,7 +196,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixTools_Sim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -211,7 +211,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimTalonSRX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -226,7 +226,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -241,7 +241,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimVictorSPX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -256,7 +256,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimPigeonIMU",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -271,7 +271,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimCANCoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -286,7 +286,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -294,14 +294,14 @@
             "binaryPlatforms": [
                 "windowsx86-64",
                 "linuxx86-64",
-                "osxx86-64"
+                "osxuniversal"
             ],
             "simMode": "swsim"
         },
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProCANcoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -309,14 +309,14 @@
             "binaryPlatforms": [
                 "windowsx86-64",
                 "linuxx86-64",
-                "osxx86-64"
+                "osxuniversal"
             ],
             "simMode": "swsim"
         },
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProPigeon2",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -324,7 +324,7 @@
             "binaryPlatforms": [
                 "windowsx86-64",
                 "linuxx86-64",
-                "osxx86-64"
+                "osxuniversal"
             ],
             "simMode": "swsim"
         }

--- a/java/CANcoder/build.gradle
+++ b/java/CANcoder/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO" version "2023.1.1-beta-6"
+    id "edu.wpi.first.GradleRIO" version "2023.1.1-beta-7"
 }
 
 sourceCompatibility = JavaVersion.VERSION_11

--- a/java/CANcoder/vendordeps/PhoenixPro.json
+++ b/java/CANcoder/vendordeps/PhoenixPro.json
@@ -1,7 +1,7 @@
 {
     "fileName": "PhoenixPro.json",
     "name": "CTRE-PhoenixPro",
-    "version": "23.0.0-beta-6",
+    "version": "23.0.0-beta-7",
     "frcYear": 2023,
     "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
     "mavenUrls": [
@@ -12,14 +12,14 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "wpiapi-java",
-            "version": "23.0.0-beta-6"
+            "version": "23.0.0-beta-7"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "tools",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -32,7 +32,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -45,7 +45,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -58,7 +58,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -71,7 +71,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -84,7 +84,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -97,7 +97,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -110,7 +110,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -123,7 +123,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -136,7 +136,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -151,7 +151,7 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "wpiapi-cpp",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixPro_WPI",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -166,7 +166,7 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "tools",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixTools",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -181,7 +181,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "wpiapi-cpp-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixPro_WPISim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -196,7 +196,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixTools_Sim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -211,7 +211,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimTalonSRX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -226,7 +226,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -241,7 +241,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimVictorSPX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -256,7 +256,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimPigeonIMU",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -271,7 +271,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimCANCoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -286,7 +286,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -301,7 +301,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProCANcoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -316,7 +316,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProPigeon2",
             "headerClassifier": "headers",
             "sharedLibrary": true,

--- a/java/CommandBasedDrive/build.gradle
+++ b/java/CommandBasedDrive/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO" version "2023.1.1-beta-6"
+    id "edu.wpi.first.GradleRIO" version "2023.1.1-beta-7"
 }
 
 sourceCompatibility = JavaVersion.VERSION_11

--- a/java/CommandBasedDrive/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/java/CommandBasedDrive/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -10,10 +10,10 @@ import com.ctre.phoenixpro.controls.DutyCycleOut;
 import com.ctre.phoenixpro.controls.Follower;
 import com.ctre.phoenixpro.hardware.Pigeon2;
 import com.ctre.phoenixpro.hardware.TalonFX;
+import com.ctre.phoenixpro.signals.InvertedValue;
 import com.ctre.phoenixpro.sim.ChassisReference;
 import com.ctre.phoenixpro.sim.Pigeon2SimState;
 import com.ctre.phoenixpro.sim.TalonFXSimState;
-import com.ctre.phoenixpro.spns.InvertedValue;
 
 import edu.wpi.first.math.kinematics.DifferentialDriveOdometry;
 import edu.wpi.first.math.system.plant.DCMotor;
@@ -124,11 +124,11 @@ public class DriveSubsystem extends SubsystemBase {
          * WPILib expects +V to be forward. Specify orientations to match that behavior.
          */
         /* left TalonFXs are CCW+ */
-        m_leftSimState.orientation = ChassisReference.CounterClockwise_Positive;
-        m_leftFollowerSimState.orientation = ChassisReference.CounterClockwise_Positive;
+        m_leftSimState.Orientation = ChassisReference.CounterClockwise_Positive;
+        m_leftFollowerSimState.Orientation = ChassisReference.CounterClockwise_Positive;
         /* right TalonFXs are CW+ */
-        m_rightSimState.orientation = ChassisReference.Clockwise_Positive;
-        m_rightFollowerSimState.orientation = ChassisReference.Clockwise_Positive;
+        m_rightSimState.Orientation = ChassisReference.Clockwise_Positive;
+        m_rightFollowerSimState.Orientation = ChassisReference.Clockwise_Positive;
 
         /* Publish field pose data to read back from */
         SmartDashboard.putData("Field", m_field);

--- a/java/CommandBasedDrive/vendordeps/PhoenixPro.json
+++ b/java/CommandBasedDrive/vendordeps/PhoenixPro.json
@@ -1,7 +1,7 @@
 {
     "fileName": "PhoenixPro.json",
     "name": "CTRE-PhoenixPro",
-    "version": "23.0.0-beta-6",
+    "version": "23.0.0-beta-7",
     "frcYear": 2023,
     "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
     "mavenUrls": [
@@ -12,14 +12,14 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "wpiapi-java",
-            "version": "23.0.0-beta-6"
+            "version": "23.0.0-beta-7"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "tools",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -32,7 +32,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -45,7 +45,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -58,7 +58,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -71,7 +71,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -84,7 +84,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -97,7 +97,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -110,7 +110,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -123,7 +123,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -136,7 +136,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -151,7 +151,7 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "wpiapi-cpp",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixPro_WPI",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -166,7 +166,7 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "tools",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixTools",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -181,7 +181,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "wpiapi-cpp-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixPro_WPISim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -196,7 +196,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixTools_Sim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -211,7 +211,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimTalonSRX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -226,7 +226,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -241,7 +241,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimVictorSPX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -256,7 +256,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimPigeonIMU",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -271,7 +271,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimCANCoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -286,7 +286,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -301,7 +301,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProCANcoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -316,7 +316,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProPigeon2",
             "headerClassifier": "headers",
             "sharedLibrary": true,

--- a/java/Falcon500ArcadeDrive/build.gradle
+++ b/java/Falcon500ArcadeDrive/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO" version "2023.1.1-beta-6"
+    id "edu.wpi.first.GradleRIO" version "2023.1.1-beta-7"
 }
 
 sourceCompatibility = JavaVersion.VERSION_11

--- a/java/Falcon500ArcadeDrive/src/main/java/frc/robot/Robot.java
+++ b/java/Falcon500ArcadeDrive/src/main/java/frc/robot/Robot.java
@@ -9,7 +9,7 @@ import com.ctre.phoenixpro.configs.TalonFXConfiguration;
 import com.ctre.phoenixpro.controls.DutyCycleOut;
 import com.ctre.phoenixpro.controls.Follower;
 import com.ctre.phoenixpro.hardware.TalonFX;
-import com.ctre.phoenixpro.spns.InvertedValue;
+import com.ctre.phoenixpro.signals.InvertedValue;
 
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.XboxController;

--- a/java/Falcon500ArcadeDrive/vendordeps/PhoenixPro.json
+++ b/java/Falcon500ArcadeDrive/vendordeps/PhoenixPro.json
@@ -1,7 +1,7 @@
 {
     "fileName": "PhoenixPro.json",
     "name": "CTRE-PhoenixPro",
-    "version": "23.0.0-beta-6",
+    "version": "23.0.0-beta-7",
     "frcYear": 2023,
     "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
     "mavenUrls": [
@@ -12,14 +12,14 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "wpiapi-java",
-            "version": "23.0.0-beta-6"
+            "version": "23.0.0-beta-7"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "tools",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -32,7 +32,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -45,7 +45,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -58,7 +58,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -71,7 +71,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -84,7 +84,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -97,7 +97,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -110,7 +110,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -123,7 +123,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -136,7 +136,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -151,7 +151,7 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "wpiapi-cpp",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixPro_WPI",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -166,7 +166,7 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "tools",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixTools",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -181,7 +181,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "wpiapi-cpp-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixPro_WPISim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -196,7 +196,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixTools_Sim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -211,7 +211,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimTalonSRX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -226,7 +226,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -241,7 +241,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimVictorSPX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -256,7 +256,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimPigeonIMU",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -271,7 +271,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimCANCoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -286,7 +286,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -301,7 +301,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProCANcoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -316,7 +316,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProPigeon2",
             "headerClassifier": "headers",
             "sharedLibrary": true,

--- a/java/Pigeon2/build.gradle
+++ b/java/Pigeon2/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO" version "2023.1.1-beta-6"
+    id "edu.wpi.first.GradleRIO" version "2023.1.1-beta-7"
 }
 
 sourceCompatibility = JavaVersion.VERSION_11

--- a/java/Pigeon2/vendordeps/PhoenixPro.json
+++ b/java/Pigeon2/vendordeps/PhoenixPro.json
@@ -1,7 +1,7 @@
 {
     "fileName": "PhoenixPro.json",
     "name": "CTRE-PhoenixPro",
-    "version": "23.0.0-beta-6",
+    "version": "23.0.0-beta-7",
     "frcYear": 2023,
     "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
     "mavenUrls": [
@@ -12,14 +12,14 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "wpiapi-java",
-            "version": "23.0.0-beta-6"
+            "version": "23.0.0-beta-7"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "tools",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -32,7 +32,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -45,7 +45,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -58,7 +58,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -71,7 +71,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -84,7 +84,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -97,7 +97,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -110,7 +110,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -123,7 +123,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -136,7 +136,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -151,7 +151,7 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "wpiapi-cpp",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixPro_WPI",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -166,7 +166,7 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "tools",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixTools",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -181,7 +181,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "wpiapi-cpp-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixPro_WPISim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -196,7 +196,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixTools_Sim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -211,7 +211,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimTalonSRX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -226,7 +226,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -241,7 +241,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimVictorSPX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -256,7 +256,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimPigeonIMU",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -271,7 +271,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimCANCoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -286,7 +286,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -301,7 +301,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProCANcoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -316,7 +316,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProPigeon2",
             "headerClassifier": "headers",
             "sharedLibrary": true,

--- a/java/PositionClosedLoop/build.gradle
+++ b/java/PositionClosedLoop/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO" version "2023.1.1-beta-6"
+    id "edu.wpi.first.GradleRIO" version "2023.1.1-beta-7"
 }
 
 sourceCompatibility = JavaVersion.VERSION_11

--- a/java/PositionClosedLoop/vendordeps/PhoenixPro.json
+++ b/java/PositionClosedLoop/vendordeps/PhoenixPro.json
@@ -1,7 +1,7 @@
 {
     "fileName": "PhoenixPro.json",
     "name": "CTRE-PhoenixPro",
-    "version": "23.0.0-beta-6",
+    "version": "23.0.0-beta-7",
     "frcYear": 2023,
     "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
     "mavenUrls": [
@@ -12,14 +12,14 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "wpiapi-java",
-            "version": "23.0.0-beta-6"
+            "version": "23.0.0-beta-7"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "tools",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -32,7 +32,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -45,7 +45,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -58,7 +58,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -71,7 +71,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -84,7 +84,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -97,7 +97,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -110,39 +110,39 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
                 "windowsx86-64",
                 "linuxx86-64",
-                "osxx86-64"
+                "osxuniversal"
             ],
             "simMode": "swsim"
         },
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
                 "windowsx86-64",
                 "linuxx86-64",
-                "osxx86-64"
+                "osxuniversal"
             ],
             "simMode": "swsim"
         },
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
                 "windowsx86-64",
                 "linuxx86-64",
-                "osxx86-64"
+                "osxuniversal"
             ],
             "simMode": "swsim"
         }
@@ -151,7 +151,7 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "wpiapi-cpp",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixPro_WPI",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -166,7 +166,7 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "tools",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixTools",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -181,7 +181,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "wpiapi-cpp-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixPro_WPISim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -196,7 +196,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixTools_Sim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -211,7 +211,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimTalonSRX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -226,7 +226,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -241,7 +241,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimVictorSPX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -256,7 +256,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimPigeonIMU",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -271,7 +271,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimCANCoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -286,7 +286,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -294,14 +294,14 @@
             "binaryPlatforms": [
                 "windowsx86-64",
                 "linuxx86-64",
-                "osxx86-64"
+                "osxuniversal"
             ],
             "simMode": "swsim"
         },
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProCANcoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -309,14 +309,14 @@
             "binaryPlatforms": [
                 "windowsx86-64",
                 "linuxx86-64",
-                "osxx86-64"
+                "osxuniversal"
             ],
             "simMode": "swsim"
         },
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProPigeon2",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -324,7 +324,7 @@
             "binaryPlatforms": [
                 "windowsx86-64",
                 "linuxx86-64",
-                "osxx86-64"
+                "osxuniversal"
             ],
             "simMode": "swsim"
         }

--- a/java/Simulation/build.gradle
+++ b/java/Simulation/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO" version "2023.1.1-beta-6"
+    id "edu.wpi.first.GradleRIO" version "2023.1.1-beta-7"
 }
 
 sourceCompatibility = JavaVersion.VERSION_11

--- a/java/Simulation/src/main/java/frc/robot/Robot.java
+++ b/java/Simulation/src/main/java/frc/robot/Robot.java
@@ -296,11 +296,11 @@ public class Robot extends TimedRobot {
         rightSensSim.setRawPosition(rightPos);
         rightSensSim.setVelocity(rightVel);
 
-        leftSim.setRawRotorPosition(leftPos * this.kGearRatio);
-        leftSim.setRotorVelocity(leftVel * this.kGearRatio);
+        leftSim.setRawRotorPosition(leftPos * kGearRatio);
+        leftSim.setRotorVelocity(leftVel * kGearRatio);
 
-        rightSim.setRawRotorPosition(rightPos * this.kGearRatio);
-        rightSim.setRotorVelocity(rightVel * this.kGearRatio);
+        rightSim.setRawRotorPosition(rightPos * kGearRatio);
+        rightSim.setRotorVelocity(rightVel * kGearRatio);
 
         imuSim.setRawYaw(m_driveSim.getHeading().getDegrees());
 
@@ -351,7 +351,7 @@ public class Robot extends TimedRobot {
 
     private double rotationsToMeters(double rotations) {
         /* Get circumference of wheel */
-        final double circumference = this.kWheelRadiusInches * 2 * Math.PI;
+        final double circumference = kWheelRadiusInches * 2 * Math.PI;
 
         /* Every rotation of the wheel travels this many inches */
         /* So now get the meters traveled per rotation */
@@ -363,7 +363,7 @@ public class Robot extends TimedRobot {
 
     private double metersToRotations(double meters) {
         /* Get circumference of wheel */
-        final double circumference = this.kWheelRadiusInches * 2 * Math.PI;
+        final double circumference = kWheelRadiusInches * 2 * Math.PI;
 
         /* Every rotation of the wheel travels this many inches */
         /* So now get the rotations per meter traveled */

--- a/java/Simulation/src/main/java/frc/robot/Robot.java
+++ b/java/Simulation/src/main/java/frc/robot/Robot.java
@@ -4,7 +4,6 @@
 
 package frc.robot;
 
-import com.ctre.phoenixpro.StatusCode;
 import com.ctre.phoenixpro.configs.CANcoderConfiguration;
 import com.ctre.phoenixpro.configs.Pigeon2Configuration;
 import com.ctre.phoenixpro.configs.TalonFXConfiguration;
@@ -12,12 +11,12 @@ import com.ctre.phoenixpro.controls.Follower;
 import com.ctre.phoenixpro.hardware.CANcoder;
 import com.ctre.phoenixpro.hardware.Pigeon2;
 import com.ctre.phoenixpro.hardware.TalonFX;
+import com.ctre.phoenixpro.signals.CANcoder_SensorDirectionValue;
+import com.ctre.phoenixpro.signals.InvertedValue;
 import com.ctre.phoenixpro.sim.CANcoderSimState;
 import com.ctre.phoenixpro.sim.ChassisReference;
 import com.ctre.phoenixpro.sim.Pigeon2SimState;
 import com.ctre.phoenixpro.sim.TalonFXSimState;
-import com.ctre.phoenixpro.spns.CANcoder_SensorDirectionValue;
-import com.ctre.phoenixpro.spns.InvertedValue;
 
 import edu.wpi.first.math.kinematics.DifferentialDriveOdometry;
 import edu.wpi.first.math.system.plant.DCMotor;
@@ -44,7 +43,7 @@ public class Robot extends TimedRobot {
 
     private final XboxController joystick = new XboxController(0);
 
-    // all CTRE devices are assumed to be on a canivore bus named "mycanivore"
+    // All CTRE devices are assumed to be on a canivore bus named "mycanivore"
     private final TalonFX leftLeader = new TalonFX(1, kCanivoreName);
     private final TalonFX rightLeader = new TalonFX(2, kCanivoreName);
     private final TalonFX leftFollower = new TalonFX(3, kCanivoreName);
@@ -55,7 +54,7 @@ public class Robot extends TimedRobot {
 
     private final Pigeon2 imu = new Pigeon2(0, kCanivoreName);
 
-    // create sim state objects for handling simulation IO
+    // Create sim state objects for handling simulation IO
     private final TalonFXSimState leftSim = leftLeader.getSimState();
     private final TalonFXSimState rightSim = rightLeader.getSimState();
     private final CANcoderSimState leftSensSim = leftSensor.getSimState();
@@ -112,26 +111,24 @@ public class Robot extends TimedRobot {
         TalonFXConfiguration fxCfg = new TalonFXConfiguration();
         fxCfg.MotorOutput.Inverted = InvertedValue.CounterClockwise_Positive;
 
-        // apply and loop in case there is an error
+        // Apply and loop in case there is an error
         for (int i = 0; i < 5; i++) {
             var result = leftLeader.getConfigurator().apply(fxCfg);
 
-            // exit, configs are successfully applied
             if (result.isOK()) {
                 break;
-            } // otherwise retry up to 5 times
+            } // Otherwise retry up to 5 times
         }
 
         fxCfg.MotorOutput.Inverted = InvertedValue.Clockwise_Positive;
         
-        // apply and loop in case there is an error
+        // Apply and loop in case there is an error
         for (int i = 0; i < 5; i++) {
             var result = rightLeader.getConfigurator().apply(fxCfg);
 
-            // exit, configs are successfully applied
             if (result.isOK()) {
                 break;
-            } // otherwise retry up to 5 times
+            } // Otherwise retry up to 5 times
         }
 
         CANcoderConfiguration cancoderConfig = new CANcoderConfiguration();
@@ -141,7 +138,6 @@ public class Robot extends TimedRobot {
         for (int i = 0; i < 5; i++) {
             var result = leftSensor.getConfigurator().apply(cancoderConfig);
 
-            // exit, configs are successfully applied
             if (result.isOK()) {
                 break;
             } // otherwise retry up to 5 times
@@ -149,26 +145,24 @@ public class Robot extends TimedRobot {
 
         cancoderConfig.MagnetSensor.SensorDirection = CANcoder_SensorDirectionValue.Clockwise_Positive;
 
-        // apply and loop in case there is an error
+        // Apply and loop in case there is an error
         for (int i = 0; i < 5; i++) {
             var result = rightSensor.getConfigurator().apply(cancoderConfig);
 
-            // exit, configs are successfully applied
             if (result.isOK()) {
                 break;
-            } // otherwise retry up to 5 times
+            } // Otherwise retry up to 5 times
         }
 
         var pigeonConfig = new Pigeon2Configuration();
 
-        // apply and loop in case there is an error
+        // Apply and loop in case there is an error
         for (int i = 0; i < 5; i++) {
             var result = imu.getConfigurator().apply(pigeonConfig);
 
-            // exit, configs are successfully applied
             if (result.isOK()) {
                 break;
-            } // otherwise retry up to 5 times
+            } // Otherwise retry up to 5 times
         }
         
         /*
@@ -197,17 +191,17 @@ public class Robot extends TimedRobot {
 
     @Override
     public void robotPeriodic() {
-        // update the odometry based on the pigeon 2 rotation and cancoder positions
+        // Update the odometry based on the pigeon 2 rotation and cancoder positions
         m_odometry.update(imu.getRotation2d(),
                 rotationsToMeters(leftSensor.getPosition().getValue()),
                 rotationsToMeters(rightSensor.getPosition().getValue()));
 
-        // update robot pose for visualization
+        // Update robot pose for visualization
         m_field.setRobotPose(m_odometry.getPoseMeters());
 
-        // print sensor values 50 loops
-        // or every ~1 second (20ms loop time)
-        // users can alternatively publish these values to WPILib SmartDashboard
+        // Print sensor values every 50 loops,
+        // this is ~1s assuming 20ms loop times.
+        // Users can alternatively publish these values to WPILib SmartDashboard
         if (printCount >= 50) {
             printCount = 0;
 
@@ -233,14 +227,14 @@ public class Robot extends TimedRobot {
          * and outputs are not affected by user-level inversion.
          * However, inputs and outputs *are* affected by the mechanical
          * orientation of the device relative to the robot chassis,
-         * as specified by the `orientation` field.
+         * as specified by the `Orientation` field.
          *
          */
-        leftSim.orientation = ChassisReference.CounterClockwise_Positive;
-        leftSensSim.orientation = ChassisReference.CounterClockwise_Positive;
+        leftSim.Orientation = ChassisReference.CounterClockwise_Positive;
+        leftSensSim.Orientation = ChassisReference.CounterClockwise_Positive;
         
-        rightSim.orientation = ChassisReference.Clockwise_Positive;
-        rightSensSim.orientation = ChassisReference.Clockwise_Positive;
+        rightSim.Orientation = ChassisReference.Clockwise_Positive;
+        rightSensSim.Orientation = ChassisReference.Clockwise_Positive;
     }
 
     @Override
@@ -303,7 +297,6 @@ public class Robot extends TimedRobot {
         rightSim.setRotorVelocity(rightVel * kGearRatio);
 
         imuSim.setRawYaw(m_driveSim.getHeading().getDegrees());
-
 
         /*
          * If a bumper is pressed, trigger the forward limit switch to test it, 

--- a/java/Simulation/vendordeps/PhoenixPro.json
+++ b/java/Simulation/vendordeps/PhoenixPro.json
@@ -1,7 +1,7 @@
 {
     "fileName": "PhoenixPro.json",
     "name": "CTRE-PhoenixPro",
-    "version": "23.0.0-beta-6",
+    "version": "23.0.0-beta-7",
     "frcYear": 2023,
     "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
     "mavenUrls": [
@@ -12,14 +12,14 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "wpiapi-java",
-            "version": "23.0.0-beta-6"
+            "version": "23.0.0-beta-7"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "tools",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -32,7 +32,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -45,7 +45,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -58,7 +58,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -71,7 +71,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -84,7 +84,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -97,7 +97,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -110,7 +110,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -123,7 +123,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -136,7 +136,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -151,7 +151,7 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "wpiapi-cpp",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixPro_WPI",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -166,7 +166,7 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "tools",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixTools",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -181,7 +181,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "wpiapi-cpp-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixPro_WPISim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -196,7 +196,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixTools_Sim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -211,7 +211,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimTalonSRX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -226,7 +226,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -241,7 +241,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimVictorSPX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -256,7 +256,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimPigeonIMU",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -271,7 +271,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimCANCoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -286,7 +286,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -301,7 +301,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProCANcoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -316,7 +316,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProPigeon2",
             "headerClassifier": "headers",
             "sharedLibrary": true,

--- a/java/VelocityClosedLoop/build.gradle
+++ b/java/VelocityClosedLoop/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO" version "2023.1.1-beta-6"
+    id "edu.wpi.first.GradleRIO" version "2023.1.1-beta-7"
 }
 
 sourceCompatibility = JavaVersion.VERSION_11

--- a/java/VelocityClosedLoop/vendordeps/PhoenixPro.json
+++ b/java/VelocityClosedLoop/vendordeps/PhoenixPro.json
@@ -1,7 +1,7 @@
 {
     "fileName": "PhoenixPro.json",
     "name": "CTRE-PhoenixPro",
-    "version": "23.0.0-beta-6",
+    "version": "23.0.0-beta-7",
     "frcYear": 2023,
     "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
     "mavenUrls": [
@@ -12,14 +12,14 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "wpiapi-java",
-            "version": "23.0.0-beta-6"
+            "version": "23.0.0-beta-7"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "tools",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -32,7 +32,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -45,7 +45,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -58,7 +58,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -71,7 +71,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -84,7 +84,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -97,7 +97,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -110,39 +110,39 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
                 "windowsx86-64",
                 "linuxx86-64",
-                "osxx86-64"
+                "osxuniversal"
             ],
             "simMode": "swsim"
         },
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
                 "windowsx86-64",
                 "linuxx86-64",
-                "osxx86-64"
+                "osxuniversal"
             ],
             "simMode": "swsim"
         },
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
                 "windowsx86-64",
                 "linuxx86-64",
-                "osxx86-64"
+                "osxuniversal"
             ],
             "simMode": "swsim"
         }
@@ -151,7 +151,7 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "wpiapi-cpp",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixPro_WPI",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -166,7 +166,7 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "tools",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixTools",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -181,7 +181,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "wpiapi-cpp-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixPro_WPISim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -196,7 +196,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_PhoenixTools_Sim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -211,7 +211,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimTalonSRX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -226,7 +226,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -241,7 +241,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimVictorSPX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -256,7 +256,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimPigeonIMU",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -271,7 +271,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimCANCoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -286,7 +286,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -294,14 +294,14 @@
             "binaryPlatforms": [
                 "windowsx86-64",
                 "linuxx86-64",
-                "osxx86-64"
+                "osxuniversal"
             ],
             "simMode": "swsim"
         },
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProCANcoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -309,14 +309,14 @@
             "binaryPlatforms": [
                 "windowsx86-64",
                 "linuxx86-64",
-                "osxx86-64"
+                "osxuniversal"
             ],
             "simMode": "swsim"
         },
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.0-beta-6",
+            "version": "23.0.0-beta-7",
             "libName": "CTRE_SimProPigeon2",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -324,7 +324,7 @@
             "binaryPlatforms": [
                 "windowsx86-64",
                 "linuxx86-64",
-                "osxx86-64"
+                "osxuniversal"
             ],
             "simMode": "swsim"
         }


### PR DESCRIPTION
- Cleanup spacing
- Adjust comments to be consistent
- Update to WPILib beta 7
- Use `with*` builder when appropriate
- C++ use K&R since that's what WPILib uses
